### PR TITLE
Add support for miniupnp API v14+

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1019,10 +1019,14 @@ void ThreadMapPort2(void* parg)
 #ifndef UPNPDISCOVER_SUCCESS
     /* miniupnpc 1.5 */
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0);
-#else
+#elif MINIUPNPC_API_VERSION < 14
     /* miniupnpc 1.6 */
     int error = 0;
     devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, &error);
+#else
+    /* miniupnpc 1.9+ */
+    int error = 0;
+    devlist = upnpDiscover(2000, multicastif, minissdpdpath, 0, 0, 2, &error);
 #endif
 
     struct UPNPUrls urls;


### PR DESCRIPTION
```
API version 14
miniupnpc.h
  add ttl argument to upnpDiscover() upnpDiscoverAll() upnpDiscoverDevice()
  upnpDiscoverDevices()
```
[https://github.com/miniupnp/miniupnp/blob/master/miniupnpc/Changelog.txt](https://github.com/miniupnp/miniupnp/blob/7848d799a4a9f6ac0ac369ea438fa400140fd463/miniupnpc/Changelog.txt#L52)